### PR TITLE
Disable removal of html extension in url

### DIFF
--- a/electron/main/localServer.ts
+++ b/electron/main/localServer.ts
@@ -53,6 +53,8 @@ class LocalServer extends EventEmitter {
                     ],
 
                     public: this.currentDir,
+
+                    cleanUrls: false,
                 });
             }
         );


### PR DESCRIPTION
Отключен параметр, который убирает расширение `.html` из путей, из-за чего нельзя было сделать редирект на кастомный html-файл в папке `public`.